### PR TITLE
Add timeouts and make them configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ require "open-meteo"
 OpenMeteo.configure do |config|
   config.host = "api.my-own-open-meteo.com"
   config.logger = Rails.logger
+  config.api_key = "your_open_meteo_api_key"
 end
 ```
 

--- a/lib/open_meteo/client.rb
+++ b/lib/open_meteo/client.rb
@@ -1,6 +1,4 @@
-require "faraday"
-require "faraday/retry"
-
+require_relative "faraday_connection"
 require_relative "client/config"
 require_relative "client/url_builder"
 
@@ -13,15 +11,16 @@ module OpenMeteo
     class Timeout < StandardError
     end
 
-    # See https://github.com/lostisland/faraday-retry/tree/main#usage
-    RETRY_OPTIONS = { max: 3, interval: 0.05, interval_randomness: 0.5, backoff_factor: 3 }.freeze
-
     attr_reader :api_config, :agent
 
-    def initialize(api_config: OpenMeteo::Client::Config.new, url_builder: nil, agent: nil)
+    def initialize(
+      api_config: OpenMeteo::Client::Config.new,
+      url_builder: nil,
+      agent: FaradayConnection.new.connect
+    )
       @api_config = api_config
       @url_builder = url_builder || UrlBuilder.new(api_config:)
-      @agent = agent || Faraday.new { |f| f.request :retry, RETRY_OPTIONS }
+      @agent = agent
     end
 
     def get(endpoint_name, *endpoint_args, **get_params)

--- a/lib/open_meteo/client/config.rb
+++ b/lib/open_meteo/client/config.rb
@@ -3,12 +3,13 @@ module OpenMeteo
     ##
     # The configuration for the OpenMeteo::Client.
     class Config
-      attr_reader :api_key, :host, :logger
+      attr_reader :api_key, :host, :logger, :timeouts
 
-      def initialize(api_key: nil, host: nil, logger: nil)
+      def initialize(api_key: nil, host: nil, logger: nil, timeouts: nil)
         @api_key = api_key || OpenMeteo.configuration.api_key
         @host = host || OpenMeteo.configuration.host
         @logger = logger || OpenMeteo.configuration.logger
+        @timeouts = timeouts || OpenMeteo.configuration.timeouts
       end
 
       def url

--- a/lib/open_meteo/configuration.rb
+++ b/lib/open_meteo/configuration.rb
@@ -28,5 +28,6 @@ module OpenMeteo
     add_setting :logger, -> { Logger.new($stdout) }
     add_setting :host, "api.open-meteo.com"
     add_setting :api_key, -> { ENV.fetch("OPEN_METEO_API_KEY", nil) }
+    add_setting :timeouts, -> { { timeout: 5, open_timeout: 5 } }
   end
 end

--- a/lib/open_meteo/faraday_connection.rb
+++ b/lib/open_meteo/faraday_connection.rb
@@ -1,0 +1,26 @@
+require "faraday"
+require "faraday/retry"
+
+module OpenMeteo
+  ##
+  # The Faraday connection
+  class FaradayConnection
+    # See https://github.com/lostisland/faraday-retry/tree/main#usage
+    RETRY_OPTIONS = { max: 3, interval: 0.05, interval_randomness: 0.5, backoff_factor: 3 }.freeze
+
+    attr_reader :config
+
+    def initialize(config: OpenMeteo::Client::Config.new)
+      @config = config
+    end
+
+    def connect
+      Faraday.new do |conn|
+        conn.options[:timeout] = config.timeouts[:timeout]
+        conn.options[:open_timeout] = config.timeouts[:open_timeout]
+
+        conn.request :retry, RETRY_OPTIONS
+      end
+    end
+  end
+end


### PR DESCRIPTION
Timeout from OpenMeteo is raised after 60 seconds. I have made it configurable and also added a default of 5 seconds to respond.

I also took the advantage to isolate the Faraday agent connection.