### PR TITLE
Share configuration across classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.3.2] - 2024-03-21
+
+- Forecast class accepts a initializer config class that is shared across dependent classes.
+
 ## [0.3.1] - 2024-03-08
 
 - Add configurable timeouts

--- a/README.md
+++ b/README.md
@@ -88,15 +88,18 @@ variables = { current: %i[weather_code], hourly: %i[], daily: %i[] }
 forecast_response = forecast.get(location:, variables:)
 ```
 
-| Config key | Default value                            | Remarks                                                                             |
-| ---------- | ---------------------------------------- | ----------------------------------------------------------------------------------- |
-| `host`     | `"api.open-meteo.com"`                   |                                                                                     |
-| `api_key`  | `ENV.fetch("OPEN_METEO_API_KEY", nil)` } | Use the host `customer-api.open-meteo.com` for the commercial version of OpenMeteo. |
-| `logger`   | `Logger.new($stdout)`                    |                                                                                     |
+| Config key | Default value                            | Remarks                                                                                                                     |
+| ---------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `host`     | `"api.open-meteo.com"`                   |                                                                                                                             |
+| `api_key`  | `ENV.fetch("OPEN_METEO_API_KEY", nil)` } | Use the host `customer-api.open-meteo.com` for the commercial version of OpenMeteo.                                         |
+| `logger`   | `Logger.new($stdout)`                    |                                                                                                                             |
+| `timeouts` | `{ timeout: 5, open_timeout: 5}`         | Uses [Faraday configuration options](https://github.com/lostisland/faraday/blob/main/docs/customization/request-options.md) |
 
 ### Configuration of a client instance
 
-You can also create a client that takes a configuration that overwrites the global configuration:
+You can also create a client that takes a configuration that overwrites the global configuration.
+
+The configuration sent to the client initializer will be shared with the dependent classes:
 
 ```ruby
 # some/other/file.rb

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ You can also create a client that takes a configuration that overwrites the glob
 # some/other/file.rb
 require "open-meteo"
 
-api_config =
+config =
   OpenMeteo::Client::Config.new(logger: Logger.new($stdout), host: "api.my-own-open-meteo.com")
-client = OpenMeteo::Client.new(api_config:)
+client = OpenMeteo::Client.new(config:)
 forecast = OpenMeteo::Forecast.new(client:)
 
 location = OpenMeteo::Entities::Location.new(latitude: 52.52, longitude: 13.41)

--- a/example.rb
+++ b/example.rb
@@ -2,7 +2,7 @@ require "open_meteo"
 
 OpenMeteo.configure { |config| config.logger = Logger.new("open_meteo.log") }
 
-client = OpenMeteo::Client.new(agent: Faraday.new { |conn| conn.response :logger })
+client = OpenMeteo::Client.new
 
 location = OpenMeteo::Entities::Location.new(latitude: 52.52.to_d, longitude: 13.41.to_d)
 variables = { current: %i[], hourly: %i[weather_code temperature_2m], daily: %i[] }
@@ -13,6 +13,6 @@ puts data.current
 puts data.daily
 puts data.hourly
 puts ""
-puts data.hourly&.items&.first(5)
+puts data.hourly&.items&.first(5)&.map(&:raw_json)
 puts ""
 puts "Weather code symbol: :#{data.hourly&.items&.first&.weather_code_symbol}"

--- a/lib/open_meteo.rb
+++ b/lib/open_meteo.rb
@@ -1,3 +1,4 @@
+require "open_meteo/faraday_connection"
 require "open_meteo/types"
 require "open_meteo/configuration"
 require "open_meteo/entities/location"

--- a/lib/open_meteo/client.rb
+++ b/lib/open_meteo/client.rb
@@ -16,7 +16,7 @@ module OpenMeteo
     def initialize(
       config: OpenMeteo::Client::Config.new,
       url_builder: UrlBuilder.new(config:),
-      agent: FaradayConnection.new(config:).connect
+      agent: FaradayConnection.new(config:)
     )
       @config = config
       @url_builder = url_builder
@@ -26,7 +26,7 @@ module OpenMeteo
     def get(endpoint_name, *endpoint_args, **get_params)
       endpoint = url_builder.build_url(endpoint_name, *endpoint_args)
 
-      agent.get do |request|
+      agent.connect.get do |request|
         request.params = get_params.merge({ apikey: config.api_key }.compact)
         request.url(endpoint)
       end

--- a/lib/open_meteo/client.rb
+++ b/lib/open_meteo/client.rb
@@ -16,7 +16,7 @@ module OpenMeteo
     def initialize(
       api_config: OpenMeteo::Client::Config.new,
       url_builder: UrlBuilder.new(api_config:),
-      agent: FaradayConnection.new.connect
+      agent: FaradayConnection.new(api_config:).connect
     )
       @api_config = api_config
       @url_builder = url_builder

--- a/lib/open_meteo/client.rb
+++ b/lib/open_meteo/client.rb
@@ -11,14 +11,14 @@ module OpenMeteo
     class Timeout < StandardError
     end
 
-    attr_reader :api_config, :agent
+    attr_reader :config, :agent
 
     def initialize(
-      api_config: OpenMeteo::Client::Config.new,
-      url_builder: UrlBuilder.new(api_config:),
-      agent: FaradayConnection.new(api_config:).connect
+      config: OpenMeteo::Client::Config.new,
+      url_builder: UrlBuilder.new(config:),
+      agent: FaradayConnection.new(config:).connect
     )
-      @api_config = api_config
+      @config = config
       @url_builder = url_builder
       @agent = agent
     end
@@ -27,7 +27,7 @@ module OpenMeteo
       endpoint = url_builder.build_url(endpoint_name, *endpoint_args)
 
       agent.get do |request|
-        request.params = get_params.merge({ apikey: api_config.api_key }.compact)
+        request.params = get_params.merge({ apikey: config.api_key }.compact)
         request.url(endpoint)
       end
     rescue Faraday::ConnectionFailed => e

--- a/lib/open_meteo/client/url_builder.rb
+++ b/lib/open_meteo/client/url_builder.rb
@@ -5,15 +5,15 @@ module OpenMeteo
     class UrlBuilder
       API_PATHS = { forecast: "v1/forecast", forecast_dwd_icon: "v1/dwd-icon" }.freeze
 
-      attr_reader :api_config
+      attr_reader :config
 
-      def initialize(api_config: OpenMeteo::Client::Config.new)
-        @api_config = api_config
+      def initialize(config: OpenMeteo::Client::Config.new)
+        @config = config
       end
 
       def build_url(endpoint, *args)
         relative_path = API_PATHS.fetch(endpoint.to_sym)
-        full_path = [api_config.url, relative_path].join("/")
+        full_path = [config.url, relative_path].join("/")
 
         URI::DEFAULT_PARSER.escape(format(full_path, args))
       end

--- a/lib/open_meteo/faraday_connection.rb
+++ b/lib/open_meteo/faraday_connection.rb
@@ -20,6 +20,7 @@ module OpenMeteo
         conn.options[:open_timeout] = config.timeouts[:open_timeout]
 
         conn.request :retry, RETRY_OPTIONS
+        conn.response :logger
       end
     end
   end

--- a/lib/open_meteo/forecast.rb
+++ b/lib/open_meteo/forecast.rb
@@ -13,9 +13,9 @@ module OpenMeteo
     end
 
     def initialize(
-      api_config: OpenMeteo::Config.new,
-      client: OpenMeteo::Client.new(api_config:),
-      response_wrapper: OpenMeteo::ResponseWrapper.new(api_config:)
+      config: OpenMeteo::Client::Config.new,
+      client: OpenMeteo::Client.new(config:),
+      response_wrapper: OpenMeteo::ResponseWrapper.new(config:)
     )
       @client = client
       @response_wrapper = response_wrapper

--- a/lib/open_meteo/forecast.rb
+++ b/lib/open_meteo/forecast.rb
@@ -12,7 +12,11 @@ module OpenMeteo
     class WrongLocationType < StandardError
     end
 
-    def initialize(client: OpenMeteo::Client.new, response_wrapper: OpenMeteo::ResponseWrapper.new)
+    def initialize(
+      api_config: OpenMeteo::Config.new,
+      client: OpenMeteo::Client.new(api_config:),
+      response_wrapper: OpenMeteo::ResponseWrapper.new(api_config:)
+    )
       @client = client
       @response_wrapper = response_wrapper
     end

--- a/lib/open_meteo/response_wrapper.rb
+++ b/lib/open_meteo/response_wrapper.rb
@@ -3,8 +3,8 @@ module OpenMeteo
   # Wrap the JSON body response from the OpenMeteo request.
   #
   class ResponseWrapper
-    def initialize(config: OpenMeteo::Client::Config.new)
-      @config = config
+    def initialize(api_config: OpenMeteo::Client::Config.new)
+      @config = api_config
     end
 
     def wrap(response, entity:)

--- a/lib/open_meteo/response_wrapper.rb
+++ b/lib/open_meteo/response_wrapper.rb
@@ -3,8 +3,8 @@ module OpenMeteo
   # Wrap the JSON body response from the OpenMeteo request.
   #
   class ResponseWrapper
-    def initialize(api_config: OpenMeteo::Client::Config.new)
-      @config = api_config
+    def initialize(config: OpenMeteo::Client::Config.new)
+      @config = config
     end
 
     def wrap(response, entity:)

--- a/lib/open_meteo/response_wrapper.rb
+++ b/lib/open_meteo/response_wrapper.rb
@@ -3,6 +3,8 @@ module OpenMeteo
   # Wrap the JSON body response from the OpenMeteo request.
   #
   class ResponseWrapper
+    attr_reader :config
+
     def initialize(config: OpenMeteo::Client::Config.new)
       @config = config
     end

--- a/spec/open_meteo/client/url_builder_spec.rb
+++ b/spec/open_meteo/client/url_builder_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe OpenMeteo::Client::UrlBuilder do
-  let(:builder) { described_class.new(api_config:) }
-  let(:api_config) { OpenMeteo::Client::Config.new(host: "api.example.com") }
+  let(:builder) { described_class.new(config:) }
+  let(:config) { OpenMeteo::Client::Config.new(host: "api.example.com") }
 
   describe "forecast url" do
     let(:endpoint) { :forecast }

--- a/spec/open_meteo/client_spec.rb
+++ b/spec/open_meteo/client_spec.rb
@@ -2,14 +2,26 @@ RSpec.describe OpenMeteo::Client do
   let(:client) { described_class.new(agent:, url_builder:, config:) }
 
   let(:url_builder) { instance_double OpenMeteo::Client::UrlBuilder }
-  let(:agent) { Faraday.new }
+  let(:agent) { OpenMeteo::FaradayConnection.new }
+  let(:connection) { agent.connect }
   let(:config) { OpenMeteo::Client::Config.new }
 
+  it "uses same configuration class for all dependent classes" do
+    client = described_class.new(config:)
+    expect(client.config).to eq(config)
+
+    url_builder = client.instance_variable_get(:@url_builder)
+    expect(url_builder.config).to eq(config)
+
+    agent = client.instance_variable_get(:@agent)
+    expect(agent.config).to eq(config)
+  end
+
   describe "#agent" do
-    context "when the agent is not passed in sets a default Faraday::Connection" do
+    context "when the agent is not passed in sets the default" do
       subject { described_class.new.agent }
 
-      it { is_expected.to be_instance_of(Faraday::Connection) }
+      it { is_expected.to be_instance_of(OpenMeteo::FaradayConnection) }
     end
   end
 
@@ -26,7 +38,9 @@ RSpec.describe OpenMeteo::Client do
       allow(url_builder).to receive(:build_url).with(:forecast).and_return(
         "https://api.example.com/forecast",
       )
-      allow(agent).to receive(:get).and_yield(request).and_return(faraday_response)
+
+      allow(agent).to receive(:connect).and_return(connection)
+      allow(connection).to receive(:get).and_yield(request).and_return(faraday_response)
     end
 
     it "returns a successful response" do
@@ -45,7 +59,7 @@ RSpec.describe OpenMeteo::Client do
 
     context "when there is a Faraday connection error" do
       before do
-        allow(agent).to receive(:get).and_raise(
+        allow(connection).to receive(:get).and_raise(
           Faraday::ConnectionFailed,
           "Couldn't resolve host name",
         )
@@ -60,7 +74,7 @@ RSpec.describe OpenMeteo::Client do
     end
 
     context "when there is a Faraday timeout error" do
-      before { allow(agent).to receive(:get).and_raise(Faraday::TimeoutError) }
+      before { allow(connection).to receive(:get).and_raise(Faraday::TimeoutError) }
 
       it "returns an error" do
         expect { response }.to raise_error(

--- a/spec/open_meteo/client_spec.rb
+++ b/spec/open_meteo/client_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe OpenMeteo::Client do
-  let(:client) { described_class.new(agent:, url_builder:, api_config:) }
+  let(:client) { described_class.new(agent:, url_builder:, config:) }
 
   let(:url_builder) { instance_double OpenMeteo::Client::UrlBuilder }
   let(:agent) { Faraday.new }
-  let(:api_config) { OpenMeteo::Client::Config.new }
+  let(:config) { OpenMeteo::Client::Config.new }
 
   describe "#agent" do
     context "when the agent is not passed in sets a default Faraday::Connection" do
@@ -34,7 +34,7 @@ RSpec.describe OpenMeteo::Client do
     end
 
     context "when an api key is set" do
-      before { allow(api_config).to receive(:api_key).and_return("123") }
+      before { allow(config).to receive(:api_key).and_return("123") }
 
       it "adds the api key to the request" do
         response

--- a/spec/open_meteo/forecast_spec.rb
+++ b/spec/open_meteo/forecast_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe OpenMeteo::Forecast do
   subject(:forecast) { described_class.new(client:, response_wrapper:) }
 
   let(:client) do
-    instance_double(OpenMeteo::Client, api_config: instance_double(OpenMeteo::Client::Config))
+    instance_double(OpenMeteo::Client, config: instance_double(OpenMeteo::Client::Config))
   end
   let(:response_wrapper) { instance_double(OpenMeteo::ResponseWrapper) }
   let(:faraday_response) { instance_double(Faraday::Response) }

--- a/spec/open_meteo/forecast_spec.rb
+++ b/spec/open_meteo/forecast_spec.rb
@@ -1,12 +1,21 @@
 RSpec.describe OpenMeteo::Forecast do
   subject(:forecast) { described_class.new(client:, response_wrapper:) }
 
-  let(:client) do
-    instance_double(OpenMeteo::Client, config: instance_double(OpenMeteo::Client::Config))
-  end
+  let(:config) { instance_double(OpenMeteo::Client::Config) }
+  let(:client) { instance_double(OpenMeteo::Client, config:) }
   let(:response_wrapper) { instance_double(OpenMeteo::ResponseWrapper) }
   let(:faraday_response) { instance_double(Faraday::Response) }
   let(:forecast_entity) { instance_double(OpenMeteo::Entities::Forecast) }
+
+  it "uses same configuration class for all dependent classes" do
+    forecast = described_class.new(config:)
+
+    client = forecast.instance_variable_get(:@client)
+    expect(client.config).to eq(config)
+
+    wrapper = forecast.instance_variable_get(:@response_wrapper)
+    expect(wrapper.config).to eq(config)
+  end
 
   describe "#get" do
     subject(:forecast_get) { forecast.get(location:, variables:, model:) }

--- a/spec/open_meteo/integration/forecast/general_spec.rb
+++ b/spec/open_meteo/integration/forecast/general_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe "Integration > forecast > general" do
     context "when an API key is used" do
       subject(:response) { forecast.get(location:, variables:) }
 
-      let(:api_config) do
+      let(:config) do
         OpenMeteo::Client::Config.new(api_key: "123-test", host: "customer-api.open-meteo.com")
       end
-      let(:client) { OpenMeteo::Client.new(api_config:) }
+      let(:client) { OpenMeteo::Client.new(config:) }
       let(:forecast) { OpenMeteo::Forecast.new(client:) }
 
       it "returns a forecast" do


### PR DESCRIPTION
So we ensure that given a config class for the `OpenMeteo::Forecast` in the initializer, all the dependent classes are also using this config class.