### PR TITLE
fix(logging): uses configured logger with Faraday

### DIFF
--- a/lib/open_meteo/faraday_connection.rb
+++ b/lib/open_meteo/faraday_connection.rb
@@ -20,7 +20,7 @@ module OpenMeteo
         conn.options[:open_timeout] = config.timeouts[:open_timeout]
 
         conn.request :retry, RETRY_OPTIONS
-        conn.response :logger
+        conn.response :logger, config.logger
       end
     end
   end

--- a/spec/open_meteo/integration/configuration/logging_spec.rb
+++ b/spec/open_meteo/integration/configuration/logging_spec.rb
@@ -2,13 +2,11 @@ RSpec.describe "Integration > configuration > logging" do
   subject(:response) { forecast.get(location:, variables:) }
 
   let(:logger_stream) { StringIO.new }
-  let(:config) { OpenMeteo::Client::Config.new(logger: Logger.new(logger_stream))}
+  let(:config) { OpenMeteo::Client::Config.new(logger: Logger.new(logger_stream)) }
   let(:client) { OpenMeteo::Client.new(config:) }
   let(:forecast) { OpenMeteo::Forecast.new(client:) }
 
-  let(:location) do
-    OpenMeteo::Entities::Location.new(latitude: 52.52.to_d, longitude: 13.41.to_d)
-  end
+  let(:location) { OpenMeteo::Entities::Location.new(latitude: 52.52.to_d, longitude: 13.41.to_d) }
 
   let(:variables) do
     {
@@ -20,9 +18,8 @@ RSpec.describe "Integration > configuration > logging" do
   end
 
   it "writes to the configured logger when making requests" do
-    expect { VCR.use_cassette("integration/forecast/general") { response } }
-      .to change { logger_stream.tap(&:rewind).read }
-      .from(be_empty)
-      .to(include("Faraday"))
+    expect { VCR.use_cassette("integration/forecast/general") { response } }.to change {
+      logger_stream.tap(&:rewind).read
+    }.from(be_empty).to(include("Faraday"))
   end
 end

--- a/spec/open_meteo/integration/configuration/logging_spec.rb
+++ b/spec/open_meteo/integration/configuration/logging_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe "Integration > configuration > logging" do
+  subject(:response) { forecast.get(location:, variables:) }
+
+  let(:logger_stream) { StringIO.new }
+  let(:config) { OpenMeteo::Client::Config.new(logger: Logger.new(logger_stream))}
+  let(:client) { OpenMeteo::Client.new(config:) }
+  let(:forecast) { OpenMeteo::Forecast.new(client:) }
+
+  let(:location) do
+    OpenMeteo::Entities::Location.new(latitude: 52.52.to_d, longitude: 13.41.to_d)
+  end
+
+  let(:variables) do
+    {
+      current: %i[weather_code],
+      minutely_15: %i[weather_code],
+      hourly: %i[weather_code],
+      daily: %i[weather_code],
+    }
+  end
+
+  it "writes to the configured logger when making requests" do
+    expect { VCR.use_cassette("integration/forecast/general") { response } }
+      .to change { logger_stream.tap(&:rewind).read }
+      .from(be_empty)
+      .to(include("Faraday"))
+  end
+end


### PR DESCRIPTION
I noticed that my project's tests were showing log messages from Faraday.

I assumed that setting OpenMeteo’s logger to Rails.logger, as shown in the README, would also affect Faraday’s logger middleware.

To address this, I wrote a test to capture the missing behavior and made a simple change to pass config.logger to the Faraday response logger middleware.

If there's an established way to modify the Faraday logger setup in OpenMeteo::FaradayConnection, I'd be happy to document it in the README instead of making this change!

Please let me know how you'd prefer to proceed!