### PR TITLE
Run CI on PRs from forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   Spellcheck:


### PR DESCRIPTION
After the contribution from https://github.com/open-meteo-ruby/open-meteo-ruby/pull/92 I have seen that we are not running the CI on pull requests from a forked repository.

This should fix it.