### PR TITLE
Refactor client attributes to receive a Hash instead of free attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- refactor(UrlBuilder): use variable interpolation instead of `%s, %i` for string substitution
 - Add `timezone` to variables ([Issue #69](https://github.com/open-meteo-ruby/open-meteo-ruby/issues/69))
 - fix(logging): uses configured logger with Faraday https://github.com/cpb
 

--- a/lib/open_meteo/client.rb
+++ b/lib/open_meteo/client.rb
@@ -23,11 +23,11 @@ module OpenMeteo
       @agent = agent
     end
 
-    def get(endpoint_name, *endpoint_args, **get_params)
-      endpoint = url_builder.build_url(endpoint_name, *endpoint_args)
+    def get(endpoint_name, path_params: {}, query_params: {})
+      endpoint = url_builder.build_url(endpoint_name, path_params)
 
       agent.connect.get do |request|
-        request.params = get_params.merge({ apikey: config.api_key }.compact)
+        request.params = query_params.merge({ apikey: config.api_key }.compact)
         request.url(endpoint)
       end
     rescue Faraday::ConnectionFailed => e

--- a/lib/open_meteo/client/url_builder.rb
+++ b/lib/open_meteo/client/url_builder.rb
@@ -11,11 +11,11 @@ module OpenMeteo
         @config = config
       end
 
-      def build_url(endpoint, *args)
+      def build_url(endpoint, path_params = {})
         relative_path = API_PATHS.fetch(endpoint.to_sym)
         full_path = [config.url, relative_path].join("/")
 
-        URI::DEFAULT_PARSER.escape(format(full_path, args))
+        URI::DEFAULT_PARSER.escape(format(full_path, path_params))
       end
     end
   end

--- a/lib/open_meteo/entities/location.rb
+++ b/lib/open_meteo/entities/location.rb
@@ -12,7 +12,7 @@ module OpenMeteo
         OpenMeteo::Entities::Contracts::LocationContract.validate!(to_hash)
       end
 
-      def to_get_params
+      def to_query_params
         { latitude:, longitude: }
       end
     end

--- a/lib/open_meteo/forecast.rb
+++ b/lib/open_meteo/forecast.rb
@@ -57,8 +57,8 @@ module OpenMeteo
     end
 
     def get_forecast(endpoint, location, variables)
-      get_params = { **location.to_get_params, **variables.to_get_params }
-      response = client.get(endpoint, **get_params)
+      query_params = { **location.to_query_params, **variables.to_query_params }
+      response = client.get(endpoint, query_params:)
 
       @response_wrapper.wrap(response, entity: OpenMeteo::Entities::Forecast)
     end

--- a/lib/open_meteo/forecast/variables.rb
+++ b/lib/open_meteo/forecast/variables.rb
@@ -27,16 +27,16 @@ module OpenMeteo
       )
       attribute(:timezone, OpenMeteo::Types::Strict::String.optional.default(nil))
 
-      def to_get_params
-        get_params = {}
+      def to_query_params
+        query_params = {}
 
         %i[current minutely_15 hourly daily models].each do |key|
-          get_params[key] = send(key).join(",") if send(key) != []
+          query_params[key] = send(key).join(",") if send(key) != []
         end
 
-        %i[timezone].each { |key| get_params[key] = send(key) if send(key) }
+        %i[timezone].each { |key| query_params[key] = send(key) if send(key) }
 
-        get_params
+        query_params
       end
     end
   end

--- a/spec/open_meteo/client_spec.rb
+++ b/spec/open_meteo/client_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe OpenMeteo::Client do
     end
 
     before do
-      allow(url_builder).to receive(:build_url).with(:forecast).and_return(
+      allow(url_builder).to receive(:build_url).with(:forecast, {}).and_return(
         "https://api.example.com/forecast",
       )
 

--- a/spec/open_meteo/entities/location_spec.rb
+++ b/spec/open_meteo/entities/location_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe OpenMeteo::Entities::Location do
   let(:latitude) { nil }
   let(:longitude) { nil }
 
-  describe "#to_get_params" do
-    subject { location.to_get_params }
+  describe "#to_query_params" do
+    subject { location.to_query_params }
 
     let(:latitude) { 1.1.to_d }
     let(:longitude) { 2.2.to_d }

--- a/spec/open_meteo/forecast/variables_spec.rb
+++ b/spec/open_meteo/forecast/variables_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe OpenMeteo::Forecast::Variables do
   let(:models) { [] }
   let(:timezone) { nil }
 
-  describe "#to_get_params" do
-    subject { variables.to_get_params }
+  describe "#to_query_params" do
+    subject { variables.to_query_params }
 
     context "when no variables are set" do
-      subject { described_class.new.to_get_params }
+      subject { described_class.new.to_query_params }
 
       it { is_expected.to eq({}) }
     end

--- a/spec/open_meteo/forecast_spec.rb
+++ b/spec/open_meteo/forecast_spec.rb
@@ -42,15 +42,17 @@ RSpec.describe OpenMeteo::Forecast do
 
     context "when the location and the variables are valid" do
       let(:variables) { { hourly: %i[apparent_temperature], daily: %i[apparent_temperature_max] } }
-
-      before do
-        allow(client).to receive(:get).with(
-          :forecast,
+      let(:query_params) do
+        {
           longitude: 1.1,
           latitude: 2.2,
           hourly: "apparent_temperature",
           daily: "apparent_temperature_max",
-        ).and_return(faraday_response)
+        }
+      end
+
+      before do
+        allow(client).to receive(:get).with(:forecast, query_params:).and_return(faraday_response)
         allow(response_wrapper).to receive(:wrap).with(
           faraday_response,
           entity: OpenMeteo::Entities::Forecast,


### PR DESCRIPTION
The intention of this change is make the code more readable and easy to scale.

`query_params` and `path_params` are a more accurate names to use when building an URL.  

Also `path_params` (although we are still not using them in our endpoints) will allow to send a hash, so urls defined in the UrlBuilder class will use _variable interpolation_.

Instead of how it would look now:

```ruby
API_PATHS = { 
  forecast: "v1/forecast",
  forecast_dwd_icon: "v1/dwd-icon",
  new_endpoint: "v1/forecast/%s"       <========== 
}.freeze
```

On which we build the url missing the context of the variables:

```ruby
endpoint = url_builder.build_url(endpoint_name, "my-product" )
```

It will use variable interpolation:

```ruby
API_PATHS = { 
  forecast: "v1/forecast",
  forecast_dwd_icon: "v1/dwd-icon",
  new_endpoint: "v1/forecast/%<product>s"       <========== 
}.freeze
```
So we will call the build url with a clear context of variables values:

```ruby
endpoint = url_builder.build_url(endpoint_name, path_params: { product: "my-product" } )
```

 