### PR TITLE
Add missing forecast variables

### DIFF
--- a/lib/open_meteo/forecast/variables.rb
+++ b/lib/open_meteo/forecast/variables.rb
@@ -26,6 +26,10 @@ module OpenMeteo
         OpenMeteo::Types::Strict::Array.of(OpenMeteo::Types::Strict::Symbol).default([].freeze),
       )
       attribute(:timezone, OpenMeteo::Types::Strict::String.optional.default(nil))
+      attribute(:past_days, OpenMeteo::Types::Strict::Integer.optional.default(nil))
+      attribute(:forecast_days, OpenMeteo::Types::Strict::Integer.optional.default(nil))
+      attribute(:start_date, OpenMeteo::Types::Strict::String.optional.default(nil))
+      attribute(:end_date, OpenMeteo::Types::Strict::String.optional.default(nil))
 
       def to_query_params
         query_params = {}
@@ -34,7 +38,9 @@ module OpenMeteo
           query_params[key] = send(key).join(",") if send(key) != []
         end
 
-        %i[timezone].each { |key| query_params[key] = send(key) if send(key) }
+        %i[timezone past_days forecast_days start_date end_date].each do |key|
+          query_params[key] = send(key) if send(key)
+        end
 
         query_params
       end


### PR DESCRIPTION
OpenMeteo Forecast API now has additional variables: `past_days`, `forecast_days`, `start_date` and `end_date` to harness past data. This PR adds support for these variables in the gem

https://open-meteo.com/en/docs
![CleanShot 2025-04-29 at 12 22 14](https://github.com/user-attachments/assets/04e17f2d-1305-4fa9-a249-afb3cff8cd72)
